### PR TITLE
Fix store typing and typo

### DIFF
--- a/src/features/ollama-api/streaming-logic/infra/stream-source-store.ts
+++ b/src/features/ollama-api/streaming-logic/infra/stream-source-store.ts
@@ -7,6 +7,7 @@ export interface StreamSourceState {
   setIsStreaming: (isLoading: boolean) => void;
   addChunk: (chunk: string) => void;
   message: string;
+  reset: () => void;
 }
 
 export const useStreamSourceStore = create<StreamSourceState>()(

--- a/src/lib/cond8/directors/create-workflow/actors/accumulator.ts
+++ b/src/lib/cond8/directors/create-workflow/actors/accumulator.ts
@@ -18,7 +18,7 @@ export const createAccumulatorActors = <C8 extends WorkflowConduit>() => {
     },
   };
 
-  const Summurize = {
+  const Summarize = {
     Into: (setKey: string) => (c8: C8) => {
       c8.var(setKey, c8.assistAcc.getAcc());
       return c8;
@@ -29,6 +29,6 @@ export const createAccumulatorActors = <C8 extends WorkflowConduit>() => {
     From,
     Finalize,
     Reset,
-    Summurize,
+    Summarize,
   };
 };

--- a/src/lib/cond8/directors/create-workflow/start-create-workflow.ts
+++ b/src/lib/cond8/directors/create-workflow/start-create-workflow.ts
@@ -78,7 +78,7 @@ StartCreateWorkflowDirector(
   Actors.Stream.Stop,
 )(
   // === When aligned, summarize and reset accumulators, then transition to enrichment phase ===
-  Actors.Accumulator.Summurize.Into('Refined Inputs'),
+  Actors.Accumulator.Summarize.Into('Refined Inputs'),
   Actors.Accumulator.Reset,
   Actors.Prompt.Reset,
 


### PR DESCRIPTION
## Summary
- add missing `reset` method to `StreamSourceState`
- rename `Summurize` actor to `Summarize`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: missing modules)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684485d7cf088329bf950a5794ed70bb