### PR TITLE
Fix summarizer actor naming

### DIFF
--- a/src/lib/cond8/directors/create-workflow/actors/accumulator.ts
+++ b/src/lib/cond8/directors/create-workflow/actors/accumulator.ts
@@ -18,7 +18,7 @@ export const createAccumulatorActors = <C8 extends WorkflowConduit>() => {
     },
   };
 
-  const Summurize = {
+  const Summarize = {
     Into: (setKey: string) => (c8: C8) => {
       c8.var(setKey, c8.assistAcc.getAcc());
       return c8;
@@ -29,6 +29,6 @@ export const createAccumulatorActors = <C8 extends WorkflowConduit>() => {
     From,
     Finalize,
     Reset,
-    Summurize,
+    Summarize,
   };
 };

--- a/src/lib/cond8/directors/create-workflow/start-create-workflow.ts
+++ b/src/lib/cond8/directors/create-workflow/start-create-workflow.ts
@@ -78,7 +78,7 @@ StartCreateWorkflowDirector(
   Actors.Stream.Stop,
 )(
   // === When aligned, summarize and reset accumulators, then transition to enrichment phase ===
-  Actors.Accumulator.Summurize.Into('Refined Inputs'),
+  Actors.Accumulator.Summarize.Into('Refined Inputs'),
   Actors.Accumulator.Reset,
   Actors.Prompt.Reset,
 


### PR DESCRIPTION
## Summary
- rename `Summurize` to `Summarize`
- update usage in `start-create-workflow.ts`

## Testing
- `pnpm test` *(fails: No test suite found)*
- `pnpm build` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6844872a50d483298a4600e426e3127c